### PR TITLE
Exit recoverShares if any incoming value is empty

### DIFF
--- a/frontend/wasm/wasm.go
+++ b/frontend/wasm/wasm.go
@@ -39,6 +39,9 @@ func recoverShares(this js.Value, i []js.Value) interface{} {
 	inStrings := make([]string, i[0].Length())
 	for k := 0; k < i[0].Length(); k++ {
 		inStrings[k] = i[0].Index(k).String()
+		if len(inStrings[k]) == 0 {
+			return js.ValueOf("")
+		}
 	}
 
 	inBytes := make([][]byte, len(inStrings))

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/sharedsecret v0.0.0-20200414095807-b90bfadc28af h1:RPL9y7YMFYjvNfgQrZCZbba+d5Wg0AoFWm47V3UIi0E=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -5,3 +5,7 @@ github.com/pkg/errors
 ## explicit
 github.com/posener/sharedsecret
 github.com/posener/sharedsecret/internal/polynom
+# github.com/shurcooL/go v0.0.0-20200502201357-93f07166e636
+## explicit
+# github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041
+## explicit


### PR DESCRIPTION
If the first value in the incoming fields is empty, this will cause a array out of bounds error later on.  Also the message cannot be decrypted yet as not all fields are present.

Also ran `go mod vendor` to update the `modules.txt` file.