### PR TITLE
func TestSecretSharingSameShares: rand.Intn(n int) panics if n <= 0

### DIFF
--- a/s4_test.go
+++ b/s4_test.go
@@ -46,7 +46,7 @@ func TestSecretSharingSameShares(t *testing.T) {
 	input := make([]byte, rand.Intn(30000-1000)+1000)
 	rand.Read(input)
 
-	n := uint64(rand.Intn(10-2) + 2)
+	n := uint64(rand.Intn(10-2) + 4)
 	k := uint64(rand.Intn(int(n)-2) + 2)
 
 	shares, err := DistributeBytes(input, n, k)


### PR DESCRIPTION
If merged, this pull request addresses the issue that `func TestSecretSharingSameShares` panics depending on what value is assigned to `n`.

Background: From the docs, `rand.Intn(myInt int)` returns a a non-negative pseudo-random number in `[0,myInt)`.   It panics if `myInt <= 0`.

Here if `n` is assigned 0, 1, or 2 then the line where `k` is defined panics.

**Note**:  This test still fails.  This PR addresses the random element of this test failing.  The remaining element will be addressed in a different PR.