### PR TITLE
Replaces mention of posener/sharedsecret with hashicorp/vault to catc…

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -60,8 +60,8 @@
                         works completely offline. Save it to your computer (Ctrl+S) in order to not lose access to the
                         s4 in case this website will be down at any point in the future.</p>
                     <p> Please note that s4 is provided as it is and I do not take responsibility for any bugs. s4 is a
-                        tiny layer around <a href="https://github.com/posener/sharedsecret"
-                            target="_blank">sharedsecret</a> and golangs <a
+                        tiny layer around <a href="https://github.com/hashicorp/vault"
+                            target="_blank">hashicorp vault shamir</a> and golangs <a
                             href="https://github.com/gtank/cryptopasta/blob/master/encrypt.go" target="_blank">AES
                             encryption</a>.</p>
                     <p>If you find any issues, please report them via <a href="https://github.com/simonfrey/s4/issues"


### PR DESCRIPTION
…h up with code change

https://github.com/simonfrey/s4/commit/c5934512c30db8030831bd293a3b291b2f9a8678 I think changes from github.com/posener/sharedsecret to github.com/hashicorp/vault ; this updates the text in the index.html to reflect that