### PR TITLE
Prevent running dom modifications before dom is loaded

### DIFF
--- a/frontend/js/decrypt.js
+++ b/frontend/js/decrypt.js
@@ -1,5 +1,8 @@
 // trigger initial render for decrypt tab
-handleShareChange();
+window.addEventListener('DOMContentLoaded', function() {
+  handleShareChange();
+});
+
 
 function handleShareChange() {
   var total = document.getElementById("decryptShares").valueAsNumber;

--- a/frontend/js/tabs.js
+++ b/frontend/js/tabs.js
@@ -1,5 +1,7 @@
-// set initial tab
-changeTab('encrypt');
+window.addEventListener('DOMContentLoaded', function() {
+  // set initial tab
+  changeTab('encrypt');
+});
 
 function changeTab(activeTab) {
   // loop through tab handles


### PR DESCRIPTION
I think this will solve #20

When loaded locally, the javascript could execute _before_ the DOM was parsed, leading to a situation where the decrypt inputs didn't have events attached to them.